### PR TITLE
Show images in thumb

### DIFF
--- a/app/views/application/_thumbnail_core.html.erb
+++ b/app/views/application/_thumbnail_core.html.erb
@@ -2,6 +2,11 @@
   <div class="caption">
     <h5><%= @thumb_obj[:name] %></h5>
     </h5>
+    <% if @thumb_obj[:image].present? %>
+      <div class="image-wrapper">
+       <%= image_tag @thumb_obj[:image]%>
+      </div>
+    <% end %>
     <p>
       <%= "#{@thumb_obj[:overview]}" %>
       <%#= link_to "[...]", eval("#{@thumb_obj[:link]}_path(#{@thumb_obj[:id]})") %>


### PR DESCRIPTION
Look like this:

![screen shot 2015-04-17 at 10 22 22 pm](https://cloud.githubusercontent.com/assets/1570168/7214213/938eaeb8-e555-11e4-9e1b-127de297524b.png)

An explicit decision was made to keep the title above the image, because that's where the user expects it to be.