### PR TITLE
Fix overflow of case studies and design methods pages

### DIFF
--- a/app/views/case_studies/index.html.erb
+++ b/app/views/case_studies/index.html.erb
@@ -5,31 +5,32 @@
 		$('#create-btn').css('margin-top', (pH - eH)/2)
 	});
 </script>
+<div class="container-fluid">
+	<div class = "row">
+		<div class="col-md-2">
 
-<div class = "row">
-	<div class="col-md-2">
-
+		</div>
+	  	<div class="col-md-10 left-pad">
+		<div class="col-md-6">
+			<h3>Feautured Case Studies</h3>
+		</div>
+	  	<div class="col-md-6">
+	  		<%= link_to new_case_study_path, :id => "create-btn", :class => "btn btn-default pull-right"  do %>
+	  			<span class="glyphicon glyphicon-plus"></span>
+	  			Add Case Study
+	  		<% end %>
+	  	</div>
+	  	</div>
 	</div>
-  	<div class="col-md-10 left-pad">
-	<div class="col-md-6">
-		<h3>Feautured Case Studies</h3>
+	<div class = "row">
+		<div class="col-md-2">
+			<!-- WARNING: SIDEBAR UNDER CONSTRUCTION! -->
+		</div>
+	  	<div class="col-md-10 left-pad">
+	  	  <% @case_studies.each do |cs| %>
+	  	  	<%= render "/layouts/thumbnail", locals: @thumb_obj = thumbnail(cs,"3") %>
+	      <% end %>
+	    </div>
 	</div>
-  	<div class="col-md-6">
-  		<%= link_to new_case_study_path, :id => "create-btn", :class => "btn btn-default pull-right"  do %>
-  			<span class="glyphicon glyphicon-plus"></span>
-  			Add Case Study
-  		<% end %>
-  	</div>
-  	</div>
-</div>
-<div class = "row">
-	<div class="col-md-2">
-		<!-- WARNING: SIDEBAR UNDER CONSTRUCTION! -->
-	</div>
-  	<div class="col-md-10 left-pad">
-  	  <% @case_studies.each do |cs| %>
-  	  	<%= render "/layouts/thumbnail", locals: @thumb_obj = thumbnail(cs,"3") %>
-      <% end %>
-    </div>
 </div>
 

--- a/app/views/design_methods/index.html.erb
+++ b/app/views/design_methods/index.html.erb
@@ -21,28 +21,29 @@ html, body{
 </style>
 
 <!-- TOP ROW -->
-<div class="row">
-  	<div class="col-xs-8 col-xs-offset-4 col-sm-10 col-sm-offset-2  left-pad ">
-		<div class="col-xs-6">
-			<h3>Popular Methods</h3>
-		</div>
-	  	<div class="col-xs-6">
-	  		<%= link_to new_design_method_path, :id=> "create-btn", :class=> "btn btn-default pull-right" do %>
-				<span class="glyphicon glyphicon-plus"></span> Create Method</button>
-	  		<% end %>
+<div class="container-fluid">
+	<div class="row">
+	  	<div class="col-xs-8 col-xs-offset-4 col-sm-10 col-sm-offset-2  left-pad ">
+			<div class="col-xs-6">
+				<h3>Popular Methods</h3>
+			</div>
+		  	<div class="col-xs-6">
+		  		<%= link_to new_design_method_path, :id=> "create-btn", :class=> "btn btn-default pull-right" do %>
+					<span class="glyphicon glyphicon-plus"></span> Create Method</button>
+		  		<% end %>
+		  	</div>
 	  	</div>
-  	</div>
-</div>
-<!-- END TOP ROW -->
-
-<div id="search-and-filter" class="row">
-	<div id="sidebar" class="col-xs-4 col-sm-2">
-		<%= render "/layouts/sidebar", locals: @category_hash = sidebar_hash(:methods) %>
 	</div>
-  	<div id="results-container" class="col-xs-8 col-sm-10">
-  		<% @design_methods.each do |method| %>
-  		 	<%= render "/layouts/thumbnail", locals: @thumb_obj = thumbnail(method,"3") %>
-      	<% end %>
-  	</div>
-</div>
+	<!-- END TOP ROW -->
 
+	<div id="search-and-filter" class="row">
+		<div id="sidebar" class="col-xs-4 col-sm-2">
+			<%= render "/layouts/sidebar", locals: @category_hash = sidebar_hash(:methods) %>
+		</div>
+	  	<div id="results-container" class="col-xs-8 col-sm-10">
+	  		<% @design_methods.each do |method| %>
+	  		 	<%= render "/layouts/thumbnail", locals: @thumb_obj = thumbnail(method,"3") %>
+	      	<% end %>
+	  	</div>
+	</div>
+</div>

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -13,7 +13,7 @@ function enableAccordion(){
 
 <style>
   .sidebar-element{
-    padding-left: 10px;
+    padding-left: 0;
   }
 
   .sidebar-leaf{


### PR DESCRIPTION
On the design method and case studies pages, there's about 15px of overflow caused by negative margins. I added a container-fluid parent div and fixed the padding on the sidebar so it aligns with the logo.